### PR TITLE
Add Positive labels [PSCDD] - elpitazo

### DIFF
--- a/notebooks/webscraper/1.0-diego-webscraper-elpitazo.ipynb
+++ b/notebooks/webscraper/1.0-diego-webscraper-elpitazo.ipynb
@@ -1,0 +1,234 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "absolute-declaration",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import unidecode\n",
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "import multiprocessing as mp\n",
+    "import numpy as np\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "consistent-success",
+   "metadata": {},
+   "source": [
+    "# Reading data and normalizing columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "later-victim",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_excel(\"../../data/raw/ovsp_bdd_octubre.xlsx\")\n",
+    "column_names_normalized = df.columns.str.strip().str.lower().str.replace(\" \", \"_\")\n",
+    "df.columns = column_names_normalized"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "registered-platform",
+   "metadata": {},
+   "source": [
+    "# Quick and Dirty EDA: Confirming that I'm subsetting the correct number of elpitazo news"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "engaged-edward",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Confirming that I'm subsetting the correct number of elpitazo links\n",
+    "    # Result: 2483 el pitazo links\n",
+    "pitazo_mask = df.link_de_la_noticia.str.contains(\"https://elpitazo.net\",na=False)\n",
+    "df_elpitazo = df[pitazo_mask]\n",
+    "# df.link_de_la_noticia[pitazo_mask].str.split(\"/\", expand = True)[2].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "improving-heater",
+   "metadata": {},
+   "source": [
+    "# Elpitazo webscraper"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "effective-batman",
+   "metadata": {},
+   "source": [
+    "Common classes from `elpitazo`:\n",
+    "\n",
+    "- Titlo de noticia `tdb-title-text`\n",
+    "- info general de la noticia `tdb-title-text`\n",
+    "- Texto completo de la noticia class=\"tdb-block-inner td-fix-index\"\n",
+    "                            id=\"bsf_rt_marker\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "raising-sound",
+   "metadata": {},
+   "source": [
+    "## Testing with different classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "advance-catalyst",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Testing different classes\n",
+    "# The easiest way to extract the news content is to extract all p tags and then clean them.\n",
+    "\n",
+    "headers = {\n",
+    "        \"User-Agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36\"\n",
+    "    }\n",
+    "\n",
+    "URL = \"https://elpitazo.net/los-llanos/vecinos-de-varias-comunidades-de-acarigua-tienen-siete-anos-sin-agua/\"\n",
+    "page = requests.get(URL, headers=headers, timeout=20)\n",
+    "\n",
+    "soup = BeautifulSoup(page.content, \"html.parser\")\n",
+    "\n",
+    "soup.find_all(\"h1\", {\"class\": \"tdb-title-text\"}) # This snippet works well to find the news article title\n",
+    "# # soup.find_all(\"div\", {\"class\": \"tdb-block-inner td-fix-index\"})\n",
+    "# soup.find_all(\"p\", {\"class\": \"tdb-block-inner td-fix-index\"})\n",
+    "\n",
+    "ls = []\n",
+    "\n",
+    "tags_p = soup.find_all(\"p\")\n",
+    "for tags in tags_p:\n",
+    "    \n",
+    "    if tags.has_attr('class') and tags['class'][0] in ['contacto-datos', 'text-white', '__cf_email__']:\n",
+    "        continue\n",
+    "        \n",
+    "    ls.append(tags.get_text())\n",
+    "\n",
+    "' '.join(ls)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exact-lobby",
+   "metadata": {},
+   "source": [
+    "### Webscraper first pass\n",
+    "\n",
+    "TODO: Use multiprocessing instead of pandas.apply. There are too many links to do it in a sequential fashion "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "oriented-treasurer",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def webscraper_elpitazo(url:str):\n",
+    "    headers = {\n",
+    "        \"User-Agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36\"\n",
+    "    }\n",
+    "    \n",
+    "    page = requests.get(url, headers=headers, timeout=20)\n",
+    "\n",
+    "    soup = BeautifulSoup(page.content, \"html.parser\")\n",
+    "    \n",
+    "    tags_p = soup.find_all(\"p\")\n",
+    "\n",
+    "\n",
+    "    ls = [] # Temporary list\n",
+    "    for tags in tags_p:\n",
+    "\n",
+    "        if tags.has_attr('class') and tags['class'][0] in ['contacto-datos', 'text-white', '__cf_email__']:\n",
+    "            continue\n",
+    "\n",
+    "        ls.append(tags.get_text())\n",
+    "\n",
+    "    complete_news = ' '.join(ls)\n",
+    "    \n",
+    "    return complete_news"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "decimal-disorder",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Single URL Test\n",
+    "URL = \"https://elpitazo.net/los-llanos/el-gas-domestico-en-acarigua-araure-cuesta-entre-10-y-20-dolares/\"\n",
+    "webscraper_elpitazo(url=URL)\n",
+    "\n",
+    "# pd.series text \n",
+    "elpitazo_text = df_elpitazo.head().link_de_la_noticia.apply(webscraper_elpitazo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "superb-trance",
+   "metadata": {},
+   "source": [
+    "## Multiprocessing implementation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "extraordinary-chemistry",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: Implement parallel processing. \n",
+    "\n",
+    "def parallelize_dataframe(df, func):\n",
+    "    num_processes = mp.cpu_count()\n",
+    "    \n",
+    "    df_split = np.array_split(df, num_processes)\n",
+    "    \n",
+    "    with mp.Pool(num_processes) as p:\n",
+    "        df = pd.concat(p.map(func, df_split))\n",
+    "    return df\n",
+    "\n",
+    "parallelize_dataframe(df_elpitazo.head(),webscraper_elpitazo )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/webscraper/1.0-diego-webscraper-elpitazo.ipynb
+++ b/notebooks/webscraper/1.0-diego-webscraper-elpitazo.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "absolute-declaration",
+   "id": "insured-baker",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,12 +12,13 @@
     "import requests\n",
     "from bs4 import BeautifulSoup\n",
     "import multiprocessing as mp\n",
-    "import numpy as np\n"
+    "import numpy as np\n",
+    "import swifter\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "consistent-success",
+   "id": "forced-rehabilitation",
    "metadata": {},
    "source": [
     "# Reading data and normalizing columns"
@@ -26,7 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "later-victim",
+   "id": "pacific-puppy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "registered-platform",
+   "id": "descending-interest",
    "metadata": {},
    "source": [
     "# Quick and Dirty EDA: Confirming that I'm subsetting the correct number of elpitazo news"
@@ -46,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "engaged-edward",
+   "id": "czech-pointer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "improving-heater",
+   "id": "genetic-victory",
    "metadata": {},
    "source": [
     "# Elpitazo webscraper"
@@ -68,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "effective-batman",
+   "id": "greater-senior",
    "metadata": {},
    "source": [
     "Common classes from `elpitazo`:\n",
@@ -81,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "raising-sound",
+   "id": "personalized-michael",
    "metadata": {},
    "source": [
     "## Testing with different classes"
@@ -90,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "advance-catalyst",
+   "id": "million-defendant",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "exact-lobby",
+   "id": "normal-costs",
    "metadata": {},
    "source": [
     "### Webscraper first pass\n",
@@ -136,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "oriented-treasurer",
+   "id": "rough-invasion",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "decimal-disorder",
+   "id": "celtic-jackson",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,8 +182,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "split-physiology",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
-   "id": "superb-trance",
+   "id": "official-indiana",
    "metadata": {},
    "source": [
     "## Multiprocessing implementation"
@@ -191,22 +200,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "extraordinary-chemistry",
+   "id": "marked-jewel",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: Implement parallel processing. \n",
+    "# Parallel processing. \n",
     "\n",
-    "def parallelize_dataframe(df, func):\n",
-    "    num_processes = mp.cpu_count()\n",
+    "# First try: Didn't work\n",
+    "# def parallelize_dataframe(df, func):\n",
+    "#     num_processes = mp.cpu_count()\n",
     "    \n",
-    "    df_split = np.array_split(df, num_processes)\n",
+    "#     df_split = np.array_split(df, num_processes)\n",
     "    \n",
-    "    with mp.Pool(num_processes) as p:\n",
-    "        df = pd.concat(p.map(func, df_split))\n",
-    "    return df\n",
+    "#     with mp.Pool(num_processes) as p:\n",
+    "#         df = pd.concat(p.map(func, df_split))\n",
+    "#     return df\n",
     "\n",
-    "parallelize_dataframe(df_elpitazo.head(),webscraper_elpitazo )"
+    "# parallelize_dataframe(df_elpitazo.link_de_la_noticia.head(),webscraper_elpitazo )\n",
+    "\n",
+    "# Second try with swifter library: THIS WORKED, however there must be a faster solution\n",
+    "elpitazo_textfull = df_elpitazo.link_de_la_noticia.swifter.apply(webscraper_elpitazo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "august-mailing",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save webscraped text\n",
+    "elpitazo_textfull.to_csv(\"../../data/interim/webscraping/links_elpitazo_03132021.csv\")\n",
+    "\n",
+    "# Join with original df\n",
+    "df_elpitazo_fulltext = df.join(elpitazo_textfull,rsuffix=\"_fulltext\", how = \"left\")\n",
+    "\n",
+    "# Save link noticia and full text to check the quality of the web scraper\n",
+    "df_elpitazo_fulltext[[\"link_de_la_noticia\",\"link_de_la_noticia_fulltext\"]].to_csv(\"../../data/interim/webscraping/fulltext_links_elpitazo_03132021.csv\")\n",
+    "\n",
+    "# Remove columns that were empty (this happened because I read the data from excel)\n",
+    "unnamed_cols = df_elpitazo_fulltext.columns[df_elpitazo_fulltext.columns.str.contains(\"unnamed\")]\n",
+    "df_elpitazo_fulltext = df_elpitazo_fulltext.drop(unnamed_cols, axis = 1)\n",
+    "df_elpitazo_fulltext.to_csv(\"../../data/processed/webscraping/ovsp_bdd_elpitazotext.csv\")"
    ]
   }
  ],

--- a/notebooks/webscraper/1.0-diego-webscraper-elpitazo.ipynb
+++ b/notebooks/webscraper/1.0-diego-webscraper-elpitazo.ipynb
@@ -3,10 +3,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "insured-baker",
+   "id": "educated-playlist",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NOTE: You must include swifter and multiprocessing in your lock file. The lock file won't be merged to master\n",
     "import pandas as pd\n",
     "import unidecode\n",
     "import requests\n",
@@ -18,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "forced-rehabilitation",
+   "id": "first-implement",
    "metadata": {},
    "source": [
     "# Reading data and normalizing columns"
@@ -27,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pacific-puppy",
+   "id": "located-cornwall",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,16 +39,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "descending-interest",
+   "id": "chinese-fitness",
    "metadata": {},
    "source": [
-    "# Quick and Dirty EDA: Confirming that I'm subsetting the correct number of elpitazo news"
+    "# Quick and Dirty EDA: Confirming that I'm subsetting the correct number of elpitazo news\n",
+    "\n",
+    "There are 37 duplicated `el pitazo` rows"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "czech-pointer",
+   "id": "protecting-agency",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,8 +63,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "brave-deficit",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# duplicated values\n",
+    "\n",
+    "mask_duplicated = df_elpitazo.duplicated()\n",
+    "# df_elpitazo[mask_duplicated].sort_values(\"link_de_la_noticia\") ## Uncomment to check duplicated rows\n",
+    "\n",
+    "mask_duplicated.sum()"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "genetic-victory",
+   "id": "descending-driving",
    "metadata": {},
    "source": [
     "# Elpitazo webscraper"
@@ -69,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "greater-senior",
+   "id": "brutal-aurora",
    "metadata": {},
    "source": [
     "Common classes from `elpitazo`:\n",
@@ -82,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "personalized-michael",
+   "id": "excellent-pride",
    "metadata": {},
    "source": [
     "## Testing with different classes"
@@ -91,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "million-defendant",
+   "id": "processed-peeing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,22 +129,28 @@
     "# # soup.find_all(\"div\", {\"class\": \"tdb-block-inner td-fix-index\"})\n",
     "# soup.find_all(\"p\", {\"class\": \"tdb-block-inner td-fix-index\"})\n",
     "\n",
-    "ls = []\n",
+    "# ls = []\n",
     "\n",
-    "tags_p = soup.find_all(\"p\")\n",
-    "for tags in tags_p:\n",
+    "# tags_p = soup.find_all(\"p\")\n",
+    "title = soup.get_element_text(\".tdb-title-text\", response) or \"\"\n",
+    "date = soup.get_element_text(\".entry-date\", response) or \"\"\n",
+    "author = soup.get_element_text(\".tdb-author-name\", response) or \"\"\n",
+    "\n",
+    "# body = self._get_body(response)\n",
+    "\n",
+    "# for tags in tags_p:\n",
     "    \n",
-    "    if tags.has_attr('class') and tags['class'][0] in ['contacto-datos', 'text-white', '__cf_email__']:\n",
-    "        continue\n",
+    "#     if tags.has_attr('class') and tags['class'][0] in ['contacto-datos', 'text-white', '__cf_email__']:\n",
+    "#         continue\n",
     "        \n",
-    "    ls.append(tags.get_text())\n",
+    "#     ls.append(tags.get_text())\n",
     "\n",
-    "' '.join(ls)\n"
+    "# ' '.join(ls)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "normal-costs",
+   "id": "relative-frederick",
    "metadata": {},
    "source": [
     "### Webscraper first pass\n",
@@ -137,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "rough-invasion",
+   "id": "adjusted-forum",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,8 +174,33 @@
     "\n",
     "    soup = BeautifulSoup(page.content, \"html.parser\")\n",
     "    \n",
-    "    tags_p = soup.find_all(\"p\")\n",
+    "    # Title\n",
+    "    title = soup.find(\"h1\", {\"class\": \"tdb-title-text\"}) or \"\"\n",
+    "    if type(title) != str:\n",
+    "        title = title.get_text()\n",
     "\n",
+    "    # Date and time\n",
+    "    date = soup.find(\"time\", {\"class\":\"entry-date\"}) or \"\"\n",
+    "    if type(date) != str:\n",
+    "        date = date.get_text()\n",
+    "\n",
+    "    # Author\n",
+    "    author = soup.find(\"a\", {\"class\":\"tdb-author-name\"}) or \"\"\n",
+    "    if type(author) != str:\n",
+    "        author = author.get_text()\n",
+    "\n",
+    "    # Tags. E.g., Acarigua, falta de agua, portuguesa\n",
+    "    etiquetas = soup.find(\"ul\", {\"class\":\"tdb-tags\"}) or \"\"\n",
+    "    if type(etiquetas) != str:\n",
+    "        etiquetas = \", \".join(list(etiquetas.stripped_strings))\n",
+    "\n",
+    "    # Category. E.g., los llanos\n",
+    "    category = soup.find(\"a\", {\"class\":\"tdb-entry-category\"}) or \"\"\n",
+    "    if type(category) != str:\n",
+    "        category = category.get_text() or \"\"\n",
+    "\n",
+    "    # News Text\n",
+    "    tags_p = soup.find_all(\"p\")\n",
     "\n",
     "    ls = [] # Temporary list\n",
     "    for tags in tags_p:\n",
@@ -161,15 +210,26 @@
     "\n",
     "        ls.append(tags.get_text())\n",
     "\n",
-    "    complete_news = ' '.join(ls)\n",
+    "    text = ' '.join(ls)\n",
     "    \n",
-    "    return complete_news"
+    "    webscraped_dic = {\n",
+    "        \"url\":url,\n",
+    "        \"title\":title,\n",
+    "        \"date\":date,\n",
+    "        \"author\":author,\n",
+    "        \"tags\":etiquetas,\n",
+    "        \"category\":category,\n",
+    "        \"text\":text\n",
+    "    }\n",
+    "    \n",
+    "    \n",
+    "    return webscraped_dic"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "celtic-jackson",
+   "id": "prescribed-mailman",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,21 +237,12 @@
     "URL = \"https://elpitazo.net/los-llanos/el-gas-domestico-en-acarigua-araure-cuesta-entre-10-y-20-dolares/\"\n",
     "webscraper_elpitazo(url=URL)\n",
     "\n",
-    "# pd.series text \n",
     "elpitazo_text = df_elpitazo.head().link_de_la_noticia.apply(webscraper_elpitazo)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "split-physiology",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
-   "id": "official-indiana",
+   "id": "fantastic-legislation",
    "metadata": {},
    "source": [
     "## Multiprocessing implementation"
@@ -200,12 +251,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "marked-jewel",
+   "id": "clear-scout",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Parallel processing. \n",
-    "\n",
     "# First try: Didn't work\n",
     "# def parallelize_dataframe(df, func):\n",
     "#     num_processes = mp.cpu_count()\n",
@@ -219,29 +269,53 @@
     "# parallelize_dataframe(df_elpitazo.link_de_la_noticia.head(),webscraper_elpitazo )\n",
     "\n",
     "# Second try with swifter library: THIS WORKED, however there must be a faster solution\n",
+    "\n",
+    "# Swifter uses a normal pandas apply. Main constraint: It takes quite a bit of time (around 30 min)\n",
     "elpitazo_textfull = df_elpitazo.link_de_la_noticia.swifter.apply(webscraper_elpitazo)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "august-mailing",
+   "id": "broke-average",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elpitazo_webscraped_df = pd.DataFrame.from_dict(list(elpitazo_textfull))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sized-lewis",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Save webscraped text\n",
-    "elpitazo_textfull.to_csv(\"../../data/interim/webscraping/links_elpitazo_03132021.csv\")\n",
     "\n",
-    "# Join with original df\n",
-    "df_elpitazo_fulltext = df.join(elpitazo_textfull,rsuffix=\"_fulltext\", how = \"left\")\n",
+    "elpitazo_textfull.to_csv(\"../../data/interim/webscraping/json_links_elpitazo_04242021.csv\") # I'm saving the json file just in case\n",
+    "elpitazo_webscraped_df.to_csv(\"../../data/interim/webscraping/links_elpitazo_04242021.csv\")\n",
     "\n",
-    "# Save link noticia and full text to check the quality of the web scraper\n",
-    "df_elpitazo_fulltext[[\"link_de_la_noticia\",\"link_de_la_noticia_fulltext\"]].to_csv(\"../../data/interim/webscraping/fulltext_links_elpitazo_03132021.csv\")\n",
+    "# Merge webscraped data with tagged dataframe\n",
+    "    # Note: In the merge, duplicated values are created. \n",
+    "    # This is due that I'm joining by URL. In the original tagged data, urls are not unique. \n",
+    "    # The urls are not unique because one url may have different event types (falta de servicio, protesta)\n",
+    "df_elpitazo_webscrape_join_tags = pd.merge(df_elpitazo,elpitazo_webscraped_df, left_on= \"link_de_la_noticia\", \n",
+    "                                right_on= \"url\", how = \"left\", suffixes = (\"_original\", \"_scraped\"))\n",
     "\n",
-    "# Remove columns that were empty (this happened because I read the data from excel)\n",
-    "unnamed_cols = df_elpitazo_fulltext.columns[df_elpitazo_fulltext.columns.str.contains(\"unnamed\")]\n",
-    "df_elpitazo_fulltext = df_elpitazo_fulltext.drop(unnamed_cols, axis = 1)\n",
-    "df_elpitazo_fulltext.to_csv(\"../../data/processed/webscraping/ovsp_bdd_elpitazotext.csv\")"
+    "# Drop duplicates\n",
+    "df_elpitazo_webscrape_join_tags_nodups = df_elpitazo_webscrape_join_tags.drop_duplicates()\n",
+    "f\"Total amount of duplicates after join: {df_elpitazo_webscrape_join_tags.shape[0] - df_elpitazo_webscrape_join_tags_nodups.shape[0]} records\"\n",
+    "\n",
+    "df_elpitazo_webscrape_join_tags_nodups.to_csv(\"../../data/processed/webscraping/elpitazo_positivelabels_devdataset.csv\",index = False)\n",
+    "\n",
+    "# # Save link noticia and full text to check the quality of the web scraper\n",
+    "# df_elpitazo_fulltext[[\"link_de_la_noticia\",\"link_de_la_noticia_fulltext\"]].to_csv(\"../../data/interim/webscraping/fulltext_links_elpitazo_03132021.csv\")\n",
+    "\n",
+    "# # Remove columns that were empty (this happened because I read the data from excel)\n",
+    "# unnamed_cols = df_elpitazo_fulltext.columns[df_elpitazo_fulltext.columns.str.contains(\"unnamed\")]\n",
+    "# df_elpitazo_fulltext = df_elpitazo_fulltext.drop(unnamed_cols, axis = 1)\n",
+    "# df_elpitazo_fulltext.to_csv(\"../../data/processed/webscraping/ovsp_bdd_elpitazotext.csv\")"
    ]
   }
  ],


### PR DESCRIPTION
# Important changes: 

- I have used new libraries (`Swifter` and `unidecode`). I will only push the updated `pyproject.yaml` if we include these libraries within the `src/` script.

# Problem

Extract `el pitazo` news articles' full text. 

We currenlty have 2483 `el pitazo` links within the dataset.
![image](https://user-images.githubusercontent.com/20195244/111033801-4746cf00-8413-11eb-8b49-56218457736b.png)

#Proposed Solution
- Get HTML with `requests` and parse relevant tags with `beautifulsoup`.
   - The best solution was to extract all `<p>` tags and then parse them with `beautifulsoup`.
- Run the webscraper through all `el pitazo`links 

# Tasks
- [x] Identify relevant HTML tags and classes.
- [x] Develop web scraper for a single `el pitazo` link and manually test it with multiple links to check the extracted information.
- [x] Run the web scraper through the `2483` `el pitazo` links.
   - I have shared this dataset within `#team-sambil`
- [ ] ~Add final `el pitazo webscraping` module within `c4v-py/src/data/webscraping`.~ @LDiazN is working on the productionized web scraper. 